### PR TITLE
Allow for empty arrays and custom array converters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ export function deserialize<T extends outputValue>(type: newable, deserializeDat
     mustBeArray = mustBeArray == true;
     const isArray = Array.isArray(deserializeData);
     const typeCheckValue: inputValue = isArray ? (<any>deserializeData)[0] : deserializeData;
-    let valueTypeString: string = getTypeOf(typeCheckValue);
+    let valueTypeString: string = isArray && deserializeData.length == 0 ? '' : getTypeOf(typeCheckValue);
     let objectTypeString = getTypeOfCtor(type);
     const isTypeObject = checkIsObject(valueTypeString) || ((deserializeData == null || deserializeData == undefined) && checkIsObject(objectTypeString));
 
@@ -117,7 +117,7 @@ export function deserialize<T extends outputValue>(type: newable, deserializeDat
                     throw new Error(`${propertyName} array not expected.`);
                 }
                 
-                if (isPropObject) {
+                if (isPropObject && !(propTypeString == 'object' && converters && converters[propTypeString])) {
                     newO[key] = deserialize(dataType.Type, keyValue, dataType.IsArray);
                 } else if (converters) {
                     let converter = converters[propTypeString];


### PR DESCRIPTION
Fixes #1 

Allows the creation of custom array converters. I used it to handle arrays abstract classes:
```javascript
export class SomeClass {

  @dataType(AbstractClass, true)
  @converters({
                'object': (value: object[]) => SomeClass.getAbstractClasses(value),
                'undefined': () => null
              })
  abstractClasses: AbstractClass[];

  static getAbstractClasses(acs: object[]): AbstractClass[] {
    if (acs == null) {
      return [];
    }

    const results: AbstractClass[] = [];

    for (const ac of acs) {
      if (ac['@type'] === 'Whatever') {
        results.push(new Whatever(cb[`one`], cb[`two`], cb[`three`]));
      }
    }

    return results;
  }

}
```